### PR TITLE
style: change logger.important styling

### DIFF
--- a/src/logger.ts
+++ b/src/logger.ts
@@ -24,7 +24,9 @@ function log(...args: any[]) {
  */
 function important(...args: any[]) {
   args = args.map((arg) =>
-    typeof arg === 'string' ? chalk.hex(orange)(arg) : arg,
+    typeof arg === 'string'
+      ? chalk.bold(chalk.bgMagenta(chalk.black(arg)))
+      : arg,
   );
   console.log(...args);
 }


### PR DESCRIPTION
Suggestion to change logger.important styling to differentiate it from a warning, because every time I start the debugger I think something wen't wrong 😁 

current:
![2024-10-01_16-40-51](https://github.com/user-attachments/assets/7e6e8129-bec7-49f5-b30d-8e7eefd53019)

suggestion:
![2024-10-01_16-40-22](https://github.com/user-attachments/assets/b2a7b1ef-74ce-40b8-baf7-3925f21fc6fd)
