### PR TITLE
fix: CLI CDK context parameter

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -25,6 +25,21 @@
       "cwd": "${workspaceRoot}/test/cdk-basic"
     },
     {
+      "name": "LLDebugger - CDK basic - monorepo",
+      "program": "${workspaceRoot}/node_modules/tsx/dist/cli.mjs",
+      "args": [
+        "../src/lldebugger.ts",
+        "-c environment=test",
+        "--subfolder=cdk-basic"
+      ],
+      // "args": ["../src/lldebugger.ts", "-w"],
+      "request": "launch",
+      "skipFiles": ["<node_internals>/**"],
+      "console": "integratedTerminal",
+      "type": "node",
+      "cwd": "${workspaceRoot}/test"
+    },
+    {
       "name": "LLDebugger - CDK ESM",
       "program": "${workspaceRoot}/node_modules/tsx/dist/cli.mjs",
       "args": ["../../src/lldebugger.ts", "-c environment=test"],

--- a/src/frameworks/cdkFramework.ts
+++ b/src/frameworks/cdkFramework.ts
@@ -556,7 +556,7 @@ export class CdkFramework implements IFramework {
       (acc: Record<string, string>, arg: string) => {
         const [key, value] = arg.split('=');
         if (key && value) {
-          acc[key] = value;
+          acc[key.trim()] = value.trim();
         }
         return acc;
       },

--- a/src/frameworks/cdkFrameworkWorker.mjs
+++ b/src/frameworks/cdkFrameworkWorker.mjs
@@ -11,7 +11,7 @@ parentPort.on('message', async (data) => {
     // this is global variable to store the data from the CDK code once it is executed
     global.lambdas = [];
 
-    Logger.verbose(`[Worker ${workerData.workerId}] Received message`, data);
+    Logger.verbose(`[Worker] Received message`, data);
 
     // execute code to get the data into global.lambdas
     await import(data.compileOutput);

--- a/test/cdk-basic.test.ts
+++ b/test/cdk-basic.test.ts
@@ -139,7 +139,7 @@ describe('cdk-basic', async () => {
 
   test('remove infra', async () => {
     if (process.env.CI === 'true' || process.env.RUN_TEST_FROM_CLI === 'true') {
-      await removeInfra(lldProcess, folder);
+      await removeInfra(lldProcess, folder, ['-c environment=test']);
       const lambdaName = await getFunctionName(
         folder,
         'FunctionNameTestTsCommonJs',

--- a/test/cdk-basic.test.ts
+++ b/test/cdk-basic.test.ts
@@ -24,7 +24,7 @@ describe('cdk-basic', async () => {
 
   beforeAll(async () => {
     if (process.env.CI === 'true' || process.env.RUN_TEST_FROM_CLI === 'true') {
-      lldProcess = await startDebugger(folder, ['-c=environment=test']);
+      lldProcess = await startDebugger(folder, ['-c environment=test']);
     }
   });
 

--- a/test/cdk-basic/bin/cdk-basic.ts
+++ b/test/cdk-basic/bin/cdk-basic.ts
@@ -6,7 +6,11 @@ import { CdkbasicStack2 } from '../lib/subfolder/cdk-basic-stack2';
 
 const app = new cdk.App();
 
-const environment = 'test';
+const environment = app.node.tryGetContext('environment');
+
+if (!environment) {
+  throw new Error('Environment is not set in the context');
+}
 
 new CdkbasicStack(app, 'CdkbasicStack', {
   stackName: `${environment}-lld-cdk-basic`,

--- a/test/cdk-esm.test.ts
+++ b/test/cdk-esm.test.ts
@@ -24,7 +24,7 @@ describe('cdk-esm', async () => {
 
   beforeAll(async () => {
     if (process.env.CI === 'true' || process.env.RUN_TEST_FROM_CLI === 'true') {
-      lldProcess = await startDebugger(folder, ['-c=environment=test']);
+      lldProcess = await startDebugger(folder, ['-c environment=test']);
     }
   });
 

--- a/test/cdk-esm.test.ts
+++ b/test/cdk-esm.test.ts
@@ -139,7 +139,7 @@ describe('cdk-esm', async () => {
 
   test('remove infra', async () => {
     if (process.env.CI === 'true' || process.env.RUN_TEST_FROM_CLI === 'true') {
-      await removeInfra(lldProcess, folder);
+      await removeInfra(lldProcess, folder, ['-c environment=test']);
       const lambdaName = await getFunctionName(
         folder,
         'FunctionNameTestTsCommonJs',

--- a/test/cdk-esm/bin/cdk-esm.ts
+++ b/test/cdk-esm/bin/cdk-esm.ts
@@ -8,7 +8,11 @@ import { CdkEsmStack2 } from '../lib/subfolder/cdk-esm-stack2';
 
 const app = new cdk.App();
 
-const environment = 'test';
+const environment = app.node.tryGetContext('environment');
+
+if (!environment) {
+  throw new Error('Environment is not set in the context');
+}
 
 new CdkEsmStack(app, 'CdkEsmStack', {
   stackName: `${environment}-lld-cdk-esm`,

--- a/test/terraform-basic.test.ts
+++ b/test/terraform-basic.test.ts
@@ -22,7 +22,7 @@ describe('terraform-basic', async () => {
 
   beforeAll(async () => {
     if (process.env.CI === 'true' || process.env.RUN_TEST_FROM_CLI === 'true') {
-      lldProcess = await startDebugger(folder, ['-c=environment=test']);
+      lldProcess = await startDebugger(folder);
     }
   });
 


### PR DESCRIPTION
When using CLI parameter context the key and value should be trimed.