### PR TITLE
feat: add metadata to LambdaResource

### DIFF
--- a/src/frameworks/cdkFramework.ts
+++ b/src/frameworks/cdkFramework.ts
@@ -156,6 +156,11 @@ export class CdkFramework implements IFramework {
             define: lambdaInCdk.bundling?.define,
             external: external.length > 0 ? external : undefined,
           },
+          metadata: {
+            framework: 'cdk',
+            stackName: lambdaInCdk.stackName,
+            cdkPath: lambdaInCdk.cdkPath,
+          },
         });
       }
     }

--- a/src/frameworks/samFramework.ts
+++ b/src/frameworks/samFramework.ts
@@ -198,6 +198,10 @@ export class SamFramework implements IFramework {
         handler,
         packageJsonPath,
         esBuildOptions,
+        metadata: {
+          framework: 'sam',
+          stackName,
+        },
       };
 
       lambdasDiscovered.push(lambdaResource);

--- a/src/frameworks/slsFramework.ts
+++ b/src/frameworks/slsFramework.ts
@@ -203,6 +203,9 @@ export class SlsFramework implements IFramework {
         handler,
         packageJsonPath,
         esBuildOptions,
+        metadata: {
+          framework: 'sls',
+        },
       };
 
       lambdasDiscovered.push(lambdaResource);

--- a/src/frameworks/terraformFramework.ts
+++ b/src/frameworks/terraformFramework.ts
@@ -140,6 +140,9 @@ export class TerraformFramework implements IFramework {
         handler,
         packageJsonPath,
         esBuildOptions: undefined,
+        metadata: {
+          framework: 'terraform',
+        },
       };
 
       lambdasDiscovered.push(lambdaResource);

--- a/src/types/resourcesDiscovery.ts
+++ b/src/types/resourcesDiscovery.ts
@@ -12,6 +12,22 @@ export type LambdaResource = {
   forceBundle?: boolean;
   bundlingType?: BundlingType;
   esBuildOptions?: EsBuildOptions;
+  metadata: {
+    /**
+     * Framework name
+     */
+    framework: string;
+
+    /**
+     * If framework is CDK or SAM, this is the stack name
+     */
+    stackName?: string;
+
+    /**
+     * If framework is CDK, this is the construct path
+     */
+    cdkPath?: string;
+  };
 };
 
 export enum BundlingType {


### PR DESCRIPTION
Adds metadata to `LambdaResource` to allow for finer-grained filtering of Lambda functions.  Closes #59 