### PR TITLE
Use js loader for cjs files

### DIFF
--- a/src/frameworks/cdkFramework.ts
+++ b/src/frameworks/cdkFramework.ts
@@ -283,8 +283,9 @@ export class CdkFramework implements IFramework {
           // for .mjs files, use js loader
           const fileExtension = args.path.split('.').pop();
           const loader: esbuild.Loader =
-            fileExtension === 'mjs' ? 'js' : (fileExtension as esbuild.Loader);
-
+            (fileExtension === 'mjs' || fileExtension === 'cjs')
+              ? 'js'
+              : (fileExtension as esbuild.Loader);
           // Inject code to get the file path of the Lambda function and CDK hierarchy
           if (args.path.includes('aws-cdk-lib/aws-lambda/lib/function.')) {
             const codeToFind =


### PR DESCRIPTION
Use js loader for cjs. This makes sense since `cjs` is not a valid `esbuild.loader`